### PR TITLE
Add the ability to run send/recv together

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,6 +38,8 @@ send: native-build
 recv: native-build
 	${M}/ports/unix/micropython test_schc.py recv
 
+send_recv: native-build
+	${M}/ports/unix/micropython test_schc.py send_recv
 
 run-upy:
 	${M}/ports/unix/micropython


### PR DESCRIPTION
We may want to send and receive at the same time. This does so by
using the _thread library to start two threads -- one sending, and
one receiving.

Needs to be tested with cpython